### PR TITLE
util.LuckPermsContext: add new boolean context "userlogin:has-logged-in"

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-MIT License Copyright (c) 2021 ElCholoGamer
+MIT License Copyright (c) 2022 ElCholoGamer
 
 Permission is hereby granted, free
 of charge, to any person obtaining a copy of this software and associated

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.elchologamer</groupId>
     <artifactId>UserLogin</artifactId>
-    <version>2.13.1</version>
+    <version>2.13.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>UserLogin</name>
@@ -122,6 +122,12 @@
             <groupId>org.mongodb</groupId>
             <artifactId>mongo-java-driver</artifactId>
             <version>3.12.10</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.luckperms</groupId>
+            <artifactId>api</artifactId>
+            <version>5.4</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/elchologamer/userlogin/UserLogin.java
+++ b/src/main/java/com/elchologamer/userlogin/UserLogin.java
@@ -48,6 +48,9 @@ public final class UserLogin extends JavaPlugin {
 
         getServer().getMessenger().registerOutgoingPluginChannel(this, "BungeeCord");
 
+        // Try to find LuckPerms
+        tryLoadLuckPerms();
+
         // Register FastLogin hook
         if (getServer().getPluginManager().isPluginEnabled("FastLogin")) {
             new FastLoginHook().register();
@@ -171,6 +174,16 @@ public final class UserLogin extends JavaPlugin {
 
     private void registerEvents(Listener listener) {
         getServer().getPluginManager().registerEvents(listener, this);
+    }
+
+    private void tryLoadLuckPerms() {
+        try {
+            Class.forName("net.luckperms.api.LuckPerms");
+        } catch (ClassNotFoundException e) {
+            return;
+        }
+
+        com.elchologamer.userlogin.util.LuckPermsContext.registerLuckPermsContext(plugin);
     }
 
     @Override

--- a/src/main/java/com/elchologamer/userlogin/util/LuckPermsContext.java
+++ b/src/main/java/com/elchologamer/userlogin/util/LuckPermsContext.java
@@ -1,0 +1,42 @@
+package com.elchologamer.userlogin.util;
+
+import com.elchologamer.userlogin.UserLogin;
+import com.elchologamer.userlogin.api.UserLoginAPI;
+import net.luckperms.api.LuckPerms;
+import net.luckperms.api.context.ContextCalculator;
+import net.luckperms.api.context.ContextConsumer;
+import net.luckperms.api.context.ContextSet;
+import net.luckperms.api.context.ImmutableContextSet;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.RegisteredServiceProvider;
+
+public class LuckPermsContext implements ContextCalculator<Player> {
+    public static final String key = "userlogin:has-logged-in";
+
+    public static void registerLuckPermsContext(final UserLogin plugin) {
+        final RegisteredServiceProvider<LuckPerms> provider = plugin.getServer().getServicesManager().getRegistration(LuckPerms.class);
+
+        if (provider == null) {
+            Utils.log("LuckPerms class was found, but provider was not registered yet?");
+        } else {
+            final LuckPermsContext contextCalculator = new LuckPermsContext();
+
+            final LuckPerms luckPermsApi = provider.getProvider();
+            luckPermsApi.getContextManager().registerCalculator(contextCalculator);
+
+            Utils.log("Wow, LuckPerms! Contexts were registered");
+        }
+    }
+
+    @Override
+    public void calculate(final Player target, final ContextConsumer contextConsumer) {
+        contextConsumer.accept(key, Boolean.toString(UserLoginAPI.isLoggedIn(target)));
+    }
+
+    @Override
+    public ContextSet estimatePotentialContexts() {
+        final ImmutableContextSet.Builder builder = ImmutableContextSet.builder().add(key, "true").add(key, "false");
+        return builder.build();
+    }
+
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,7 +5,7 @@ main: 'com.elchologamer.userlogin.UserLogin'
 author: 'ElCholoGamer'
 description: 'A simple-to-use authentication system.'
 website: 'https://www.spigotmc.org/resources/userlogin.80669/'
-softdepend: ['FastLogin']
+softdepend: [ 'FastLogin', 'LuckPerms' ]
 
 permissions:
   ul.*:


### PR DESCRIPTION
It has two self-documenting values: `true` and `false`. It's optional and will be registered only when LuckPerms is found. It was tested on two 1.19 Paper servers, but it might require more.
Also bumps version from 2.13.1 to 2.13.2-SNAPSHOT.